### PR TITLE
Fix check-links hugo-serve env variables

### DIFF
--- a/tests/scripts/check-links.sh
+++ b/tests/scripts/check-links.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 SITEROOT="$(pwd)"
 
-HUGO_RESOURCEDIR="$(pwd)"/resources systemd-run --unit=hugo-serve --user hugo serve --source "$(pwd)"/exampleSite --environment "production" --config "$(pwd)"/exampleSite/hugo.toml --port 1313 --bind 127.0.0.1
+systemd-run -E PATH="${PATH}" -E HUGO_RESOURCEDIR="$(pwd)"/resources --unit=hugo-serve --user hugo serve --source "$(pwd)"/exampleSite --environment "production" --config "$(pwd)"/exampleSite/hugo.toml --port 1313 --bind 127.0.0.1
 
 sleep 2
 


### PR DESCRIPTION
We need to specify them to systemd-run to get them into the system env

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>